### PR TITLE
Fix activation policy and add optional Quit menu

### DIFF
--- a/appdelegate.m
+++ b/appdelegate.m
@@ -11,6 +11,10 @@
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
     NSLog(@"applicationDidFinishLaunching");
+
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+    [NSApp activateIgnoringOtherApps:YES];
+
     callOnApplicationDidFinishLaunchingHandler();
 }
 

--- a/application.m
+++ b/application.m
@@ -24,9 +24,17 @@ void releaseSharedApplication() {
 
 void RunApplication() {
     @autoreleasepool {
+
+        NSString *gocoaBundleIdentifier = @"gocoa";
+        NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
+        bundleIdentifier = gocoaBundleIdentifier;
+
         [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
         [NSApp activateIgnoringOtherApps:YES];
+        [NSApp deactivate];
+        [NSApp activateIgnoringOtherApps:YES];
         [NSApp run];
+
         releaseSharedApplication();
     }
 }

--- a/application.m
+++ b/application.m
@@ -24,13 +24,7 @@ void releaseSharedApplication() {
 
 void RunApplication() {
     @autoreleasepool {
-
-        NSString *gocoaBundleIdentifier = @"gocoa";
-        NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
-        bundleIdentifier = gocoaBundleIdentifier;
-
         [NSApp run];
-
         releaseSharedApplication();
     }
 }

--- a/application.m
+++ b/application.m
@@ -29,10 +29,6 @@ void RunApplication() {
         NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
         bundleIdentifier = gocoaBundleIdentifier;
 
-        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-        [NSApp activateIgnoringOtherApps:YES];
-        [NSApp deactivate];
-        [NSApp activateIgnoringOtherApps:YES];
         [NSApp run];
 
         releaseSharedApplication();

--- a/window.go
+++ b/window.go
@@ -116,6 +116,10 @@ func (wnd *Window) SetTitle(title string) {
 	C.Window_SetTitle(wnd.winPtr, cTitle)
 }
 
+func (wnd *Window) AddDefaultQuitMenu() {
+	C.Window_AddDefaultQuitMenu(wnd.winPtr)
+}
+
 func (wnd *Window) OnDidResize(fn EventHandler) {
 	wnd.callbacks[didResize] = fn
 }

--- a/window.h
+++ b/window.h
@@ -18,3 +18,4 @@ void Window_AddTextField(void *wndPtr, TextFieldPtr tfPtr);
 void Window_AddProgressIndicator(void *wndPtr, ProgressIndicatorPtr progressIndicatorPtr);
 void Window_Update(void *wndPtr);
 void Window_SetTitle(void *wndPtr, const char* title);
+void Window_AddDefaultQuitMenu(void *wndPtr);

--- a/window.m
+++ b/window.m
@@ -36,26 +36,6 @@ void* Centered_Window_New(int goWindowID, int width, int height, const char* tit
     [window setDelegate:gocoa_windowDelegate];
     [window setFrame:NSMakeRect(xPos, yPos, NSWidth([window frame]), NSHeight([window frame])) display:YES];
     
-    
-    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-
-    id menubar = [[NSMenu new] autorelease];
-    id appMenuItem = [[NSMenuItem new] autorelease];
-    [menubar addItem:appMenuItem];
-    [NSApp setMainMenu:menubar];
-    id appMenu = [[NSMenu new] autorelease];
-    id appName = [[NSProcessInfo processInfo] processName];
-    id quitTitle = [@"Quit " stringByAppendingString:appName];
-    id quitMenuItem = [[[NSMenuItem alloc] initWithTitle:quitTitle
-        action:@selector(terminate:) keyEquivalent:@"q"] autorelease];
-    [appMenu addItem:quitMenuItem];
-    [appMenuItem setSubmenu:appMenu];
-
-    [window makeKeyAndOrderFront:nil];
-    [NSApp activateIgnoringOtherApps:YES];
-    
-    
-    
     return window;
 }
 
@@ -131,5 +111,21 @@ void Window_SetTitle(void *wndPtr, const char* title)
 {
     NSWindow* window = (NSWindow*)wndPtr;
     [window setTitle:[NSString stringWithUTF8String:title]];
+}
+
+void Window_AddDefaultQuitMenu(void *wndPtr) {
+    NSWindow* window = (NSWindow*)wndPtr;
+
+    id menubar = [[NSMenu new] autorelease];
+    id appMenuItem = [[NSMenuItem new] autorelease];
+    [menubar addItem:appMenuItem];
+    [NSApp setMainMenu:menubar];
+    id appMenu = [[NSMenu new] autorelease];
+    id appName = [[NSProcessInfo processInfo] processName];
+    id quitTitle = [@"Quit " stringByAppendingString:appName];
+    id quitMenuItem = [[[NSMenuItem alloc] initWithTitle:quitTitle
+        action:@selector(terminate:) keyEquivalent:@"q"] autorelease];
+    [appMenu addItem:quitMenuItem];
+    [appMenuItem setSubmenu:appMenu];
 }
 

--- a/window.m
+++ b/window.m
@@ -35,6 +35,27 @@ void* Centered_Window_New(int goWindowID, int width, int height, const char* tit
     [gocoa_windowDelegate setGoWindowID:goWindowID];
     [window setDelegate:gocoa_windowDelegate];
     [window setFrame:NSMakeRect(xPos, yPos, NSWidth([window frame]), NSHeight([window frame])) display:YES];
+    
+    
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+
+    id menubar = [[NSMenu new] autorelease];
+    id appMenuItem = [[NSMenuItem new] autorelease];
+    [menubar addItem:appMenuItem];
+    [NSApp setMainMenu:menubar];
+    id appMenu = [[NSMenu new] autorelease];
+    id appName = [[NSProcessInfo processInfo] processName];
+    id quitTitle = [@"Quit " stringByAppendingString:appName];
+    id quitMenuItem = [[[NSMenuItem alloc] initWithTitle:quitTitle
+        action:@selector(terminate:) keyEquivalent:@"q"] autorelease];
+    [appMenu addItem:quitMenuItem];
+    [appMenuItem setSubmenu:appMenu];
+
+    [window makeKeyAndOrderFront:nil];
+    [NSApp activateIgnoringOtherApps:YES];
+    
+    
+    
     return window;
 }
 
@@ -111,3 +132,4 @@ void Window_SetTitle(void *wndPtr, const char* title)
     NSWindow* window = (NSWindow*)wndPtr;
     [window setTitle:[NSString stringWithUTF8String:title]];
 }
+


### PR DESCRIPTION
This fixes the application's activation policy preventing us from clicking the application menu at all and in addition adds a new function to add a default quit menu item (with CMD + Q support).

**Example:**
```go
wnd.AddDefaultQuitMenu()
```

![quit](https://user-images.githubusercontent.com/5388534/132652936-916f9626-ac62-4f80-91d5-5eba0069ab8c.png)
